### PR TITLE
Support `has_count :xxx, foreign_key: :yyy`

### DIFF
--- a/lib/active_record/associations/builder/has_count.rb
+++ b/lib/active_record/associations/builder/has_count.rb
@@ -5,7 +5,7 @@ module ActiveRecord::Associations::Builder
     end
 
     def valid_options
-      []
+      [:foreign_key]
     end
 
     def self.valid_dependent_options


### PR DESCRIPTION
READMEの例だと、例えばこういう風にhas_countのレシーバのクラス名とカラム名が異なるときにforeign_keyがサポートされていると嬉しいです。

``` ruby
class AbstractTweet < ActiveRecord::Base
  has_count :replies_count, foreign_key: :tweet_id
end

class Tweet < AbstractTweet
end
```
