### PR TITLE
Support an association with a scope

### DIFF
--- a/lib/active_record/precount/has_many_extension.rb
+++ b/lib/active_record/precount/has_many_extension.rb
@@ -16,7 +16,7 @@ module ActiveRecord
           name_with_count = options[:count_loader] if options[:count_loader].is_a?(Symbol)
 
           valid_options = options.slice(*Associations::Builder::CountLoader.valid_options)
-          reflection = Associations::Builder::CountLoader.build(model, name_with_count, nil, valid_options)
+          reflection = Associations::Builder::CountLoader.build(model, name_with_count, scope, valid_options)
           Reflection.add_reflection(model, name_with_count, reflection)
         end
       end

--- a/lib/active_record/precount/relation_extension.rb
+++ b/lib/active_record/precount/relation_extension.rb
@@ -32,8 +32,10 @@ module ActiveRecord
           raise ArgumentError, "Association named '#{arg}' was not found on #{klass.name}." unless has_reflection?(arg)
           next if has_reflection?(counter_name = :"#{arg}_count")
 
-          options = reflection_for(arg).options.slice(*Associations::Builder::CountLoader.valid_options)
-          reflection = Associations::Builder::CountLoader.build(klass, counter_name, nil, options)
+          original_reflection = reflection_for(arg)
+          scope = original_reflection.scope
+          options = original_reflection.options.slice(*Associations::Builder::CountLoader.valid_options)
+          reflection = Associations::Builder::CountLoader.build(klass, counter_name, scope, options)
           Reflection.add_reflection(model, counter_name, reflection)
         end
       end

--- a/test/cases/associations/eager_count_test.rb
+++ b/test/cases/associations/eager_count_test.rb
@@ -27,9 +27,9 @@ class EagerCountTest < ActiveRecord::CountLoader::TestCase
   end
 
   def test_eager_count_defines_count_loader
-    assert_equal(Tweet.has_reflection?(:favs_count), false)
+    assert_equal(false, Tweet.has_reflection?(:favs_count))
     Tweet.eager_count(:favs).map(&:favs_count)
-    assert_equal(Tweet.has_reflection?(:favs_count), true)
+    assert_equal(true, Tweet.has_reflection?(:favs_count))
   end
 
   def test_eager_count_has_many_with_count_loader_does_not_execute_n_1_queries
@@ -41,14 +41,14 @@ class EagerCountTest < ActiveRecord::CountLoader::TestCase
 
   def test_eager_count_has_many_counts_properly
     expected = Tweet.order(id: :asc).map { |t| t.favorites.count }
-    assert_equal(Tweet.order(id: :asc).map(&:favorites_count), expected)
-    assert_equal(Tweet.order(id: :asc).eager_count(:favorites).map { |t| t.favorites.count }, expected)
-    assert_equal(Tweet.order(id: :asc).eager_count(:favorites).map(&:favorites_count), expected)
+    assert_equal(expected, Tweet.order(id: :asc).map(&:favorites_count))
+    assert_equal(expected, Tweet.order(id: :asc).eager_count(:favorites).map { |t| t.favorites.count })
+    assert_equal(expected, Tweet.order(id: :asc).eager_count(:favorites).map(&:favorites_count))
   end
 
   def test_eager_count_has_many_with_scope_counts_properly
     expected = Tweet.order(id: :asc).map { |t| t.my_favs.count }
-    assert_equal(Tweet.order(id: :asc).eager_count(:my_favs).map { |t| t.my_favs.count }, expected)
-    assert_equal(Tweet.order(id: :asc).eager_count(:my_favs).map(&:my_favs_count), expected)
+    assert_equal(expected, Tweet.order(id: :asc).eager_count(:my_favs).map { |t| t.my_favs.count })
+    assert_equal(expected, Tweet.order(id: :asc).eager_count(:my_favs).map(&:my_favs_count))
   end
 end

--- a/test/cases/associations/eager_count_test.rb
+++ b/test/cases/associations/eager_count_test.rb
@@ -2,9 +2,11 @@ require 'cases/helper'
 
 class EagerCountTest < ActiveRecord::CountLoader::TestCase
   def setup
-    tweets_count.times.map do |index|
+    tweets_count.times do |i|
       tweet = Tweet.create
-      index.times { Favorite.create(tweet: tweet) }
+      i.times do |j|
+        Favorite.create(tweet: tweet, user_id: j + 1)
+      end
     end
 
     if Tweet.has_reflection?(:favs_count)
@@ -42,5 +44,11 @@ class EagerCountTest < ActiveRecord::CountLoader::TestCase
     assert_equal(Tweet.order(id: :asc).map(&:favorites_count), expected)
     assert_equal(Tweet.order(id: :asc).eager_count(:favorites).map { |t| t.favorites.count }, expected)
     assert_equal(Tweet.order(id: :asc).eager_count(:favorites).map(&:favorites_count), expected)
+  end
+
+  def test_eager_count_has_many_with_scope_counts_properly
+    expected = Tweet.order(id: :asc).map { |t| t.my_favs.count }
+    assert_equal(Tweet.order(id: :asc).eager_count(:my_favs).map { |t| t.my_favs.count }, expected)
+    assert_equal(Tweet.order(id: :asc).eager_count(:my_favs).map(&:my_favs_count), expected)
   end
 end

--- a/test/cases/associations/eager_load_test.rb
+++ b/test/cases/associations/eager_load_test.rb
@@ -4,9 +4,11 @@ require 'models/tweet'
 
 class EagerLoadTest < ActiveRecord::CountLoader::TestCase
   def setup
-    tweets_count.times.map do |index|
+    tweets_count.times do |i|
       tweet = Tweet.create
-      index.times { Favorite.create(tweet: tweet) }
+      i.times do |j|
+        Favorite.create(tweet: tweet, user_id: j + 1)
+      end
     end
   end
 
@@ -29,5 +31,11 @@ class EagerLoadTest < ActiveRecord::CountLoader::TestCase
     assert_equal(Tweet.order(id: :asc).map(&:favorites_count), expected)
     assert_equal(Tweet.order(id: :asc).eager_load(:favorites_count).map { |t| t.favorites.count }, expected)
     assert_equal(Tweet.order(id: :asc).eager_load(:favorites_count).map(&:favorites_count), expected)
+  end
+
+  def test_eager_loaded_count_loader_with_scope_counts_properly
+    expected = Tweet.order(id: :asc).map { |t| t.my_favorites.count }
+    assert_equal(Tweet.order(id: :asc).eager_load(:my_favorites_count).map { |t| t.my_favorites.count }, expected)
+    assert_equal(Tweet.order(id: :asc).eager_load(:my_favorites_count).map(&:my_favorites_count), expected)
   end
 end

--- a/test/cases/associations/eager_load_test.rb
+++ b/test/cases/associations/eager_load_test.rb
@@ -28,14 +28,14 @@ class EagerLoadTest < ActiveRecord::CountLoader::TestCase
 
   def test_eager_loaded_count_loader_counts_properly
     expected = Tweet.order(id: :asc).map { |t| t.favorites.count }
-    assert_equal(Tweet.order(id: :asc).map(&:favorites_count), expected)
-    assert_equal(Tweet.order(id: :asc).eager_load(:favorites_count).map { |t| t.favorites.count }, expected)
-    assert_equal(Tweet.order(id: :asc).eager_load(:favorites_count).map(&:favorites_count), expected)
+    assert_equal(expected, Tweet.order(id: :asc).map(&:favorites_count))
+    assert_equal(expected, Tweet.order(id: :asc).eager_load(:favorites_count).map { |t| t.favorites.count })
+    assert_equal(expected, Tweet.order(id: :asc).eager_load(:favorites_count).map(&:favorites_count))
   end
 
   def test_eager_loaded_count_loader_with_scope_counts_properly
     expected = Tweet.order(id: :asc).map { |t| t.my_favorites.count }
-    assert_equal(Tweet.order(id: :asc).eager_load(:my_favorites_count).map { |t| t.my_favorites.count }, expected)
-    assert_equal(Tweet.order(id: :asc).eager_load(:my_favorites_count).map(&:my_favorites_count), expected)
+    assert_equal(expected, Tweet.order(id: :asc).eager_load(:my_favorites_count).map { |t| t.my_favorites.count })
+    assert_equal(expected, Tweet.order(id: :asc).eager_load(:my_favorites_count).map(&:my_favorites_count))
   end
 end

--- a/test/cases/associations/includes_test.rb
+++ b/test/cases/associations/includes_test.rb
@@ -26,13 +26,13 @@ class IncludesTest < ActiveRecord::CountLoader::TestCase
 
   def test_included_count_loader_counts_properly
     expected = Tweet.all.map { |t| t.favorites.count }
-    assert_equal(Tweet.all.map(&:favorites_count), expected)
-    assert_equal(Tweet.includes(:favorites_count).map(&:favorites_count), expected)
+    assert_equal(expected, Tweet.all.map(&:favorites_count))
+    assert_equal(expected, Tweet.includes(:favorites_count).map(&:favorites_count))
   end
 
   def test_included_count_loader_with_scope_counts_properly
     expected = Tweet.all.map { |t| t.my_favorites.count }
-    assert_equal(Tweet.all.map(&:my_favorites_count), expected)
-    assert_equal(Tweet.includes(:my_favorites_count).map(&:my_favorites_count), expected)
+    assert_equal(expected, Tweet.all.map(&:my_favorites_count))
+    assert_equal(expected, Tweet.includes(:my_favorites_count).map(&:my_favorites_count))
   end
 end

--- a/test/cases/associations/includes_test.rb
+++ b/test/cases/associations/includes_test.rb
@@ -2,9 +2,11 @@ require 'cases/helper'
 
 class IncludesTest < ActiveRecord::CountLoader::TestCase
   def setup
-    tweets_count.times.map do |index|
+    tweets_count.times do |i|
       tweet = Tweet.create
-      index.times { Favorite.create(tweet: tweet) }
+      i.times do |j|
+        Favorite.create(tweet: tweet, user_id: j + 1)
+      end
     end
   end
 
@@ -26,5 +28,11 @@ class IncludesTest < ActiveRecord::CountLoader::TestCase
     expected = Tweet.all.map { |t| t.favorites.count }
     assert_equal(Tweet.all.map(&:favorites_count), expected)
     assert_equal(Tweet.includes(:favorites_count).map(&:favorites_count), expected)
+  end
+
+  def test_included_count_loader_with_scope_counts_properly
+    expected = Tweet.all.map { |t| t.my_favorites.count }
+    assert_equal(Tweet.all.map(&:my_favorites_count), expected)
+    assert_equal(Tweet.includes(:my_favorites_count).map(&:my_favorites_count), expected)
   end
 end

--- a/test/cases/associations/precount_test.rb
+++ b/test/cases/associations/precount_test.rb
@@ -27,9 +27,9 @@ class PrecountTest < ActiveRecord::CountLoader::TestCase
   end
 
   def test_precount_defines_count_loader
-    assert_equal(Tweet.has_reflection?(:favs_count), false)
+    assert_equal(false, Tweet.has_reflection?(:favs_count))
     Tweet.precount(:favs).map(&:favs_count)
-    assert_equal(Tweet.has_reflection?(:favs_count), true)
+    assert_equal(true, Tweet.has_reflection?(:favs_count))
   end
 
   def test_precount_has_many_with_count_loader_does_not_execute_n_1_queries
@@ -41,14 +41,14 @@ class PrecountTest < ActiveRecord::CountLoader::TestCase
 
   def test_precount_has_many_counts_properly
     expected = Tweet.all.map { |t| t.favorites.count }
-    assert_equal(Tweet.all.map(&:favorites_count), expected)
-    assert_equal(Tweet.precount(:favorites).map { |t| t.favorites.count }, expected)
-    assert_equal(Tweet.precount(:favorites).map(&:favorites_count), expected)
+    assert_equal(expected, Tweet.all.map(&:favorites_count))
+    assert_equal(expected, Tweet.precount(:favorites).map { |t| t.favorites.count })
+    assert_equal(expected, Tweet.precount(:favorites).map(&:favorites_count))
   end
 
   def test_precount_has_many_with_scope_counts_properly
     expected = Tweet.all.map { |t| t.my_favs.count }
-    assert_equal(Tweet.precount(:my_favs).map { |t| t.my_favs.count }, expected)
-    assert_equal(Tweet.precount(:my_favs).map(&:my_favs_count), expected)
+    assert_equal(expected, Tweet.precount(:my_favs).map { |t| t.my_favs.count })
+    assert_equal(expected, Tweet.precount(:my_favs).map(&:my_favs_count))
   end
 end

--- a/test/cases/associations/precount_test.rb
+++ b/test/cases/associations/precount_test.rb
@@ -2,9 +2,11 @@ require 'cases/helper'
 
 class PrecountTest < ActiveRecord::CountLoader::TestCase
   def setup
-    tweets_count.times.map do |index|
+    tweets_count.times do |i|
       tweet = Tweet.create
-      index.times { Favorite.create(tweet: tweet) }
+      i.times do |j|
+        Favorite.create(tweet: tweet, user_id: j + 1)
+      end
     end
 
     if Tweet.has_reflection?(:favs_count)
@@ -42,5 +44,11 @@ class PrecountTest < ActiveRecord::CountLoader::TestCase
     assert_equal(Tweet.all.map(&:favorites_count), expected)
     assert_equal(Tweet.precount(:favorites).map { |t| t.favorites.count }, expected)
     assert_equal(Tweet.precount(:favorites).map(&:favorites_count), expected)
+  end
+
+  def test_precount_has_many_with_scope_counts_properly
+    expected = Tweet.all.map { |t| t.my_favs.count }
+    assert_equal(Tweet.precount(:my_favs).map { |t| t.my_favs.count }, expected)
+    assert_equal(Tweet.precount(:my_favs).map(&:my_favs_count), expected)
   end
 end

--- a/test/cases/associations/preload_test.rb
+++ b/test/cases/associations/preload_test.rb
@@ -2,9 +2,11 @@ require 'cases/helper'
 
 class PreloadTest < ActiveRecord::CountLoader::TestCase
   def setup
-    tweets_count.times.map do |index|
+    tweets_count.times do |i|
       tweet = Tweet.create
-      index.times { Favorite.create(tweet: tweet) }
+      i.times do |j|
+        Favorite.create(tweet: tweet, user_id: j + 1)
+      end
     end
   end
 
@@ -26,5 +28,11 @@ class PreloadTest < ActiveRecord::CountLoader::TestCase
     expected = Tweet.all.map { |t| t.favorites.count }
     assert_equal(Tweet.all.map(&:favorites_count), expected)
     assert_equal(Tweet.preload(:favorites_count).map(&:favorites_count), expected)
+  end
+
+  def test_preloaded_count_loader_with_scope_counts_properly
+    expected = Tweet.all.map { |t| t.my_favorites.count }
+    assert_equal(Tweet.all.map(&:my_favorites_count), expected)
+    assert_equal(Tweet.preload(:my_favorites_count).map(&:my_favorites_count), expected)
   end
 end

--- a/test/cases/associations/preload_test.rb
+++ b/test/cases/associations/preload_test.rb
@@ -26,13 +26,13 @@ class PreloadTest < ActiveRecord::CountLoader::TestCase
 
   def test_preloaded_count_loader_counts_properly
     expected = Tweet.all.map { |t| t.favorites.count }
-    assert_equal(Tweet.all.map(&:favorites_count), expected)
-    assert_equal(Tweet.preload(:favorites_count).map(&:favorites_count), expected)
+    assert_equal(expected, Tweet.all.map(&:favorites_count))
+    assert_equal(expected, Tweet.preload(:favorites_count).map(&:favorites_count))
   end
 
   def test_preloaded_count_loader_with_scope_counts_properly
     expected = Tweet.all.map { |t| t.my_favorites.count }
-    assert_equal(Tweet.all.map(&:my_favorites_count), expected)
-    assert_equal(Tweet.preload(:my_favorites_count).map(&:my_favorites_count), expected)
+    assert_equal(expected, Tweet.all.map(&:my_favorites_count))
+    assert_equal(expected, Tweet.preload(:my_favorites_count).map(&:my_favorites_count))
   end
 end

--- a/test/models/tweet.rb
+++ b/test/models/tweet.rb
@@ -1,4 +1,6 @@
 class Tweet < ActiveRecord::Base
   has_many :favorites, count_loader: true
   has_many :favs, class_name: 'Favorite'
+  has_many :my_favorites, -> { where(user_id: 1) }, class_name: 'Favorite', count_loader: true
+  has_many :my_favs, -> { where(user_id: 1) }, class_name: 'Favorite'
 end


### PR DESCRIPTION
Great gem :star2: 

This misses the scope in `has_many` on counting, so I fix it.
It works well such as `has_many :my_favorites, -> { mine }, class_name: 'Favorite'`.