### PR TITLE
Add patch for ActiveRecord::AutosaveAssociation

### DIFF
--- a/lib/active_record/precount.rb
+++ b/lib/active_record/precount.rb
@@ -28,6 +28,7 @@ require "active_support/lazy_load_hooks"
 #       * collection_proxy_extension: Fallback to eager-loaded values when foo.count is called
 #
 ActiveSupport.on_load(:active_record) do
+  require "active_record/precount/autosave_association_extension"
   require "active_record/precount/base_extension"
   require "active_record/precount/collection_proxy_extension"
   require "active_record/precount/has_many_extension"

--- a/lib/active_record/precount/autosave_association_extension.rb
+++ b/lib/active_record/precount/autosave_association_extension.rb
@@ -1,0 +1,14 @@
+module ActiveRecord
+  module Precount
+    module AutosaveAssociationExtension
+      private
+
+      def save_belongs_to_association(reflection)
+        return if reflection.is_a? ActiveRecord::Reflection::CountLoaderReflection
+        super(reflection)
+      end
+    end
+  end
+
+  Base.prepend(Precount::AutosaveAssociationExtension)
+end

--- a/test/cases/associations/autosave_association_bug_reproduction_test.rb
+++ b/test/cases/associations/autosave_association_bug_reproduction_test.rb
@@ -1,0 +1,26 @@
+require 'cases/helper'
+
+class AutosaveAssociationBugReproductionTest < ActiveRecord::CountLoader::TestCase
+  def setup
+    tweets_count.times do |i|
+      tweet = Tweet.create
+      i.times do |j|
+        Favorite.create(tweet: tweet, user_id: j + 1)
+      end
+    end
+  end
+
+  def teardown
+    [Tweet, Favorite].each(&:delete_all)
+  end
+
+  def tweets_count
+    3
+  end
+
+  def test_bug_with_save_belongs_to_association_method_fixed
+    tweet = Tweet.first
+    tweet.my_favorites_count
+    assert_equal(true, tweet.save!)
+  end
+end


### PR DESCRIPTION
This closes #19 

Applied patch to `ActiveRecord::AutosaveAssociation` to prevent error by calling `#destroyed?` method to the result of `ActiveRecord::Reflection::CountLoaderReflection#load_target`

@k0kubun Could you review this?