### PR TITLE
Fix invalid count query with ordered association

### DIFF
--- a/lib/active_record/precount/preloader_extension.rb
+++ b/lib/active_record/precount/preloader_extension.rb
@@ -25,7 +25,7 @@ module ActiveRecord
 
         def query_scope(ids)
           key = model.reflections[reflection.name.to_s.sub(/_count\z/, '')].foreign_key
-          scope.where(key => ids).group(key).count(key)
+          scope.reorder(nil).where(key => ids).group(key).count(key)
         end
 
         def build_scope

--- a/test/cases/associations/precount_test.rb
+++ b/test/cases/associations/precount_test.rb
@@ -50,6 +50,15 @@ class PrecountTest < ActiveRecord::CountLoader::TestCase
     assert_equal(expected, Tweet.precount(:my_favs).map(&:my_favs_count))
   end
 
+  def test_precount_has_many_with_ordered_association_conforms_to_mysql_only_full_group_by
+    with_mysql_sql_mode('ONLY_FULL_GROUP_BY') do
+      expected = Tweet.all.map { |t| t.ordered_favorites.count }
+      assert_equal(expected, Tweet.all.map(&:ordered_favorites_count))
+      assert_equal(expected, Tweet.precount(:ordered_favorites).map { |t| t.ordered_favorites.count })
+      assert_equal(expected, Tweet.precount(:ordered_favorites).map(&:ordered_favorites_count))
+    end
+  end
+
   def test_polymorphic_precount
     expected = Tweet.all.map { |t| t.notifications.count }
     assert_equal(expected, Tweet.precount(:notifications).map(&:notifications_count))

--- a/test/cases/test_case.rb
+++ b/test/cases/test_case.rb
@@ -46,6 +46,23 @@ module ActiveRecord::CountLoader
       options.reverse_merge! ignore_none: true
       assert_queries(0, options, &block)
     end
+
+    def with_mysql_sql_mode(sql_mode)
+      connection = ActiveRecord::Base.connection
+
+      if connection.adapter_name == 'Mysql2'
+        original_sql_mode = connection.execute('SELECT @@SESSION.sql_mode').first.first
+        connection.execute("SET @@SESSION.sql_mode = '#{original_sql_mode},#{sql_mode}'")
+
+        begin
+          yield
+        ensure
+          connection.execute("SET @@SESSION.sql_mode = '#{original_sql_mode}'")
+        end
+      else
+        yield
+      end
+    end
   end
 
   class SQLCounter

--- a/test/models/tweet.rb
+++ b/test/models/tweet.rb
@@ -3,5 +3,6 @@ class Tweet < ActiveRecord::Base
   has_many :favs, class_name: 'Favorite'
   has_many :my_favorites, -> { where(user_id: 1) }, class_name: 'Favorite', count_loader: true
   has_many :my_favs, -> { where(user_id: 1) }, class_name: 'Favorite'
+  has_many :ordered_favorites, -> { order(:id) }, class_name: 'Favorite', count_loader: true
   has_many :notifications, as: :notifiable, foreign_key: :notifiable_id
 end


### PR DESCRIPTION
When using ActiveRecord::Precount against an _ordered_ association:

```ruby
class Tweet < ActiveRecord::Base
  has_many :ordered_favorites, -> { order(:id) }, class_name: 'Favorite', count_loader: true
end

Tweet.precount(:ordered_favorites).to_a
```

... it issues the following query:

```sql
SELECT
  COUNT(`favorites`.`tweet_id`) AS count_tweet_id,
  `favorites`.`tweet_id` AS favorites_tweet_id
FROM
  `favorites`
WHERE
  `favorites`.`tweet_id` IN (55, 56, 57)
GROUP BY
  `favorites`.`tweet_id`
ORDER BY
  `favorites`.`id` ASC
```

... that is invalid in most RDBs and MySQL with [`ONLY_FULL_GROUP_BY`](https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_only_full_group_by) SQL mode (which is enabled by default from MySQL 5.7).

> Expression #1 of ORDER BY clause is not in GROUP BY clause and contains
> nonaggregated column 'activerecord_unittest.favorites.id'
> which is not functionally dependent on columns in GROUP BY clause;
> this is incompatible with sql_mode=only_full_group_by

Since ordering is no concern of preloading, we can simply remove the `ORDER BY` clause.