### PR TITLE
s/query_scope/records_for for preloader_extension.rb

### DIFF
--- a/lib/active_record/precount/preloader_extension.rb
+++ b/lib/active_record/precount/preloader_extension.rb
@@ -23,7 +23,7 @@ module ActiveRecord
           end
         end
 
-        def query_scope(ids)
+        def records_for(ids)
           key = model.reflections[reflection.name.to_s.sub(/_count\z/, '')].foreign_key
           scope.reorder(nil).where(key => ids).group(key).count(key)
         end


### PR DESCRIPTION
Closes #24 for Rails v5.1.x compatibility.

`s/query_scope/records_for` for preloader_extension.rb, because AR::Associtations::Preloader::Association#query_scope was removed at https://github.com/rails/rails/pull/26379

This PR makes below 2 failing tests succeeded. Still we need to solve all failing tests [(see for CI)](https://travis-ci.org/k0kubun/activerecord-precount) for complete Rails v5.1.x support.

```rb
  7) Error:
PrecountTest#test_precount_has_many_with_scope_counts_properly:
NoMethodError: undefined method `map' for #<Favorite:0x007fd5eab49908>
Did you mean?  tap

  8) Error:
PrecountTest#test_polymorphic_precount:
NoMethodError: undefined method `map' for #<Notification:0x007fd5ee0904e0>
Did you mean?  tap
```

---

@k0kubun Would you review this 🙏 ?
