### PR TITLE
Use the latest patch version for Rails v5.1.x on ci

### DIFF
--- a/ci/Gemfile.activerecord-5.1.x
+++ b/ci/Gemfile.activerecord-5.1.x
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem 'rails', '5.1.0'
+gem 'rails', '~> 5.1.0'
 gemspec path: '..'


### PR DESCRIPTION
How about running CI with the latest patched version for Rails v5.1.x?

Currently [Rails v5.1.1](http://weblog.rubyonrails.org/2017/5/12/Rails-5-0-3-and-5-1-1-have-been-released/) is already released, but the [CI jobs](https://travis-ci.org/k0kubun/activerecord-precount/jobs/245641217) are run with Rails v5.0.0.

---

Would you take your time to review this? 🙏 