### PR TITLE
s/.count/.size for AR::Associations::Countloader.load_target

### DIFF
--- a/lib/active_record/precount/reflection_extension.rb
+++ b/lib/active_record/precount/reflection_extension.rb
@@ -5,7 +5,7 @@ module ActiveRecord
       # When this method is called, it will be N+1 query
       def load_target
         count_target = reflection.name.to_s.sub(/_count\z/, '').to_sym
-        @target = owner.association(count_target).count
+        @target = owner.association(count_target).size
 
         loaded! unless loaded?
         target


### PR DESCRIPTION
As suggested at https://github.com/k0kubun/activerecord-precount/issues/24#issuecomment-299139588, `ActiveRecord::Associations::CollectionAssociation#count` was removed at https://github.com/rails/rails/pull/26383 , causing some test failing.

Therefore, simply replacing `.size` with `.count` to get `@target` from the `HasManyAssociation` instance.

This PR makes all failing tests with saying `NoMethodError: undefined method `count' for #<ActiveRecord::Associations::HasManyAssociation:...>`.

```rb
  1) Error:
PreloadTest#test_preload_does_not_execute_n_1_queries:
NoMethodError: undefined method `count' for #<ActiveRecord::Associations::HasManyAssociation:0x000000034a48b0>
    /home/travis/build/k0kubun/activerecord-precount/lib/active_record/precount/reflection_extension.rb:8:in `load_target'
    /home/travis/build/k0kubun/activerecord-precount/ci/vendor/bundle/ruby/2.2.0/gems/activerecord-5.1.2/lib/active_record/associations/association.rb:53:in `reload'
    ...
```

---

@k0kubun I'd be glad if you take time to review this PR 🙏 